### PR TITLE
Correct MAZ creation

### DIFF
--- a/src/02 - Network Calculations.rsc
+++ b/src/02 - Network Calculations.rsc
@@ -1289,7 +1289,7 @@ Macro "Add MAZ Connectors" (Args)
     // Create set of links that new centroids can connect to
     link_tbl.SelectByQuery({
         SetName: "ValidLinks",
-        Query: "D = 1 and HCMType <> 'Freeway' and HCMType <> 'Ramp'"
+        Query: "DTWB contains 'D' and HCMType <> 'Freeway' and HCMType <> 'Ramp'"
     })
 
     SetLayer(llyr)


### PR DESCRIPTION
"D" field isn't created when MAZs are added. Added the fix.